### PR TITLE
Fix place event not canceling

### DIFF
--- a/EpicSpawners-Plugin/src/main/java/com/songoda/epicspawners/listeners/BlockListeners.java
+++ b/EpicSpawners-Plugin/src/main/java/com/songoda/epicspawners/listeners/BlockListeners.java
@@ -113,7 +113,7 @@ public class BlockListeners implements Listener {
             
             SpawnerPlaceEvent placeEvent = new SpawnerPlaceEvent(player, spawner);
             Bukkit.getPluginManager().callEvent(placeEvent);
-            if (event.isCancelled()) {
+            if (placeEvent.isCancelled()) {
                 event.setCancelled(true);
                 return;
             }


### PR DESCRIPTION
Canceling the spawn place event never worked because it wasn't checking if the SpawnPlaceEvent was canceled.