### PR TITLE
Fix towny

### DIFF
--- a/EpicSpawners-Plugin/src/main/java/com/songoda/epicspawners/hooks/HookTowny.java
+++ b/EpicSpawners-Plugin/src/main/java/com/songoda/epicspawners/hooks/HookTowny.java
@@ -16,7 +16,7 @@ public class HookTowny implements ClaimableProtectionPluginHook {
     private final Towny towny;
 
     public HookTowny() {
-        this.towny = Towny.plugin;
+        this.towny = Towny.getPlugin();
     }
 
     @Override


### PR DESCRIPTION
After towny version 0.92.0.0, the static towny plugin instance was made private. 

https://gist.github.com/electro2560/38e2766c50d518b945d829d98426fd3c

To avoid this error, change to use Towny#getPlugin method which is compatible with all versions. 